### PR TITLE
Fixing a typo in the Encode Content-Type header.

### DIFF
--- a/otohttp/server.go
+++ b/otohttp/server.go
@@ -72,7 +72,7 @@ func Encode(w http.ResponseWriter, r *http.Request, status int, v interface{}) e
 		out = gzw
 		defer gzw.Close()
 	}
-	w.Header().Set("Content-Type", "application/json; chatset=utf-8")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
 	if _, err := out.Write(b); err != nil {
 		return err


### PR DESCRIPTION
The code had a type where the Content-Type header was being set to `chatset=...` instead of `charset=...`. I don't think this really justifies any new tests but that's up to you 😄