### PR TITLE
Embed gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ oto -template ./templates/server.go.plush \
     -ignore Ignorer \
     -pkg generated \
     ./definitions/definitions.go &&
-gofmt -w ./generated/oto.gen.go ./generated/oto.gen.go &&
 oto -template ./templates/client.js.plush \
     -out ./generated/oto.gen.js \
     -ignore Ignorer \

--- a/example/generate.sh
+++ b/example/generate.sh
@@ -4,7 +4,6 @@ oto -template server.go.plush \
 	-out server.gen.go \
 	-pkg main \
 	./def
-gofmt -w server.gen.go server.gen.go
 echo "generated server.gen.go"
 
 oto -template client.js.plush \

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/format"
 	"io"
 	"io/ioutil"
 	"os"
@@ -78,6 +79,15 @@ flags:`)
 		}
 		defer f.Close()
 		w = f
+
+		// Apply gofmt to .go files
+		if strings.HasSuffix(*outfile, ".go") {
+			outb, err := format.Source([]byte(out))
+			if err != nil {
+				return err
+			}
+			out = string(outb)
+		}
 	}
 	if _, err := io.WriteString(w, out); err != nil {
 		return err


### PR DESCRIPTION
To reduce the steps needed to render templates, this patch embeds `gofmt` in `oto` and applies it when output is a .go file.
Documentation and example are updated accordingly.