### PR TITLE
feature: retain struct tags from definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/dustin/go-humanize v1.0.0
+	github.com/fatih/structtag v1.2.0
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/gobuffalo/helpers v0.4.0 // indirect
 	github.com/gobuffalo/plush v3.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gobuffalo/envy v1.6.5 h1:X3is06x7v0nW2xiy2yFbbIjwHz57CD6z6MkvqULTCm8=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=

--- a/parser.go
+++ b/parser.go
@@ -53,6 +53,7 @@ type field struct {
 	Name      string    `json:"name,omitempty"`
 	Type      fieldType `json:"type,omitempty"`
 	OmitEmpty bool      `json:"omitEmpty,omitempty"`
+	Tag       string    `json:"tag"`
 }
 
 type fieldType struct {
@@ -233,6 +234,7 @@ func (p *parser) parseObject(pkg *packages.Package, o types.Object, v *types.Str
 		if err != nil {
 			return err
 		}
+		field.Tag = v.Tag(i)
 		obj.Fields = append(obj.Fields, field)
 	}
 	p.def.Objects = append(p.def.Objects, obj)
@@ -242,6 +244,7 @@ func (p *parser) parseObject(pkg *packages.Package, o types.Object, v *types.Str
 
 func (p *parser) parseField(pkg *packages.Package, v *types.Var) (field, error) {
 	var f field
+
 	f.Name = v.Name()
 	if !v.Exported() {
 		return f, p.wrapErr(errors.New(f.Name+" must be exported"), pkg, v.Pos())

--- a/render_test.go
+++ b/render_test.go
@@ -40,3 +40,18 @@ func TestCamelizeDown(t *testing.T) {
 		}
 	}
 }
+
+func TestStructTag2(t *testing.T) {
+	for expected, in := range map[string][]string{
+		"":                            {"", ""},
+		"`db:\"name\" json:\"name\"`": {`db:"name" json:"name"`, ""},
+		"`db:\"name\" json:\"foo\" fruit:\"apple\"`": {`db:"name" json:"name"`, `json:"foo" fruit:"apple"`},
+		"`json:\"foo\"`": {"", `json:"foo"`},
+	} {
+		actual := string(structTag2(in[0], in[1]))
+
+		if actual != expected {
+			t.Errorf("%s expected: %q but got %q", in, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This utility is wonderful! I wasted so much time trying to get Twirp, gRPC working end to end with database marshalling. This utility keeps it simple.

I found myself having to add struct tags to generated structs for use with database packages. Code regen would break things. This PR retains struct tags from the original definition and allows adding/overriding of tags in templates with `structTag` helpers.

```go
// render existing tags with backticks or EMPTY
<%= struct_tag(field.Tag) %>

// render tags overriding or setting fruit key
<%= struct_tag2(field.Tag, "fruit:\"apple\"") %>
```