### PR TITLE
Created extractCommentMetadata function and added tests

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -184,3 +184,19 @@ func TestExtractExample(t *testing.T) {
 	is.Equal(example, float64(123))
 
 }
+
+func TestExtractCommentMetadata(t *testing.T) {
+	is := is.New(t)
+
+	metadata, comment, err := extractCommentMetadata(`
+		This is a comment
+		example: "With an example"
+		required: true
+		monkey: 24
+	`)
+	is.NoErr(err)
+	is.Equal(comment, "This is a comment")
+	is.Equal(metadata["example"], "With an example")
+	is.Equal(metadata["required"], true)
+	is.Equal(metadata["monkey"], float64(24))
+}


### PR DESCRIPTION
Feature add for issue #12 

Without requiring a more specific syntax in the comment, the best way I could think to extract key-value pairs from the comments was using a regular expression. I know there are mixed feelings around regex, so if I need to go another route, just let me know! 

The test is passing, but it would be worth looking at adding more test cases.
