### PR TITLE
Fixing typo in template

### DIFF
--- a/otohttp/templates/client.ts.plush
+++ b/otohttp/templates/client.ts.plush
@@ -67,7 +67,7 @@ export class Client {
 		}
 	}
 <%= for (field) in object.Fields { %>
-	<%= format_comment_text(field.Comment) %>	<%= field.NameLowerCamel %>: <%= if (field.Type.IsObject) { %><%= field.Type.TypeName %><% } else { %><%= field.Type.JSType() %><% } %><%= if (field.Type.Multiple) { %>[]<% } %>;
+	<%= format_comment_text(field.Comment) %>	<%= field.NameLowerCamel %>: <%= if (field.Type.IsObject) { %><%= field.Type.TypeName %><% } else { %><%= field.Type.JSType %><% } %><%= if (field.Type.Multiple) { %>[]<% } %>;
 <% } %>
 }
 <% } %>


### PR DESCRIPTION
The template is trying to access a "method" called `field.Type.JSType()`. It should be `field.Type.JSType`.