### PR TITLE
Fix typo in code gen step of Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ Use the `oto` tool to generate a client and server:
 ```bash
 mkdir generated
 oto -template ./templates/server.go.plush \
-    -out ./oto.gen.go \
+    -out ./generated/oto.gen.go \
     -ignore Ignorer \
     -pkg generated \
-    ./definition
+    ./definitions
 gofmt -w ./oto.gen.go ./oto.gen.go
 oto -template ./templates/client.js.plush \
-    -out ./oto.gen.js \
+    -out ./generated/oto.gen.js \
     -ignore Ignorer \
-    ./definition
+    ./definitions
 ```
 
 - Run `oto -help` for more information about these flags


### PR DESCRIPTION
Paths were incorrect in the code gen step of the Tutorial. This threw me off for a few minutes. Hopefully this patch can save some folks time in the future.