### PR TITLE
fix parse type: field must be exported

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -211,6 +211,27 @@ You will love it.`)
 	// log.Println(string(b))
 }
 
+func TestParseUnexportedFields(t *testing.T) {
+	t.Run("response field", func(t *testing.T) {
+		is := is.New(t)
+		patterns := []string{"./testdata/unexported-fields"}
+		p := New(patterns...)
+		p.Verbose = testing.Verbose()
+		_, err := p.Parse()
+		is.True(err != nil)
+		is.True(strings.Contains(err.Error(), "result must be exported"))
+	})
+
+	t.Run("deeper field", func(t *testing.T) {
+		is := is.New(t)
+		patterns := []string{"./testdata/unexported-deeper-fields"}
+		p := New(patterns...)
+		p.Verbose = testing.Verbose()
+		_, err := p.Parse()
+		is.NoErr(err)
+	})
+}
+
 func TestFieldTypeIsOptional(t *testing.T) {
 	is := is.New(t)
 

--- a/parser/testdata/unexported-deeper-fields/unexported-deeper-fields.go
+++ b/parser/testdata/unexported-deeper-fields/unexported-deeper-fields.go
@@ -1,0 +1,14 @@
+package unexporteddeeper
+
+import "math/big"
+
+type CalculatorService interface {
+	Calculate(CalculateRequest) CalculateResponse
+}
+
+type CalculateRequest struct{}
+
+type CalculateResponse struct {
+	// big.Int has unexported fields
+	Result big.Int
+}

--- a/parser/testdata/unexported-fields/unexported-fields.go
+++ b/parser/testdata/unexported-fields/unexported-fields.go
@@ -1,0 +1,11 @@
+package unexported
+
+type CalculatorService interface {
+	Calculate(CalculateRequest) CalculateResponse
+}
+
+type CalculateRequest struct{}
+
+type CalculateResponse struct {
+	result int
+}


### PR DESCRIPTION
Parsing the below example fails with the error: `parse output object type: parse type: /usr/local/go/src/math/big/int.go:34:2: neg must be exported`.

```go
type CalculatorService interface {
	Calculate(CalculateRequest) CalculateResponse
}

type CalculateRequest struct{}

type CalculateResponse struct {
	// big.Int has unexported fields
	Result big.Int
}
```

This pull request fixes this, but still errors if the request or response object has an unexported field:

```go
type CalculatorService interface {
	Calculate(CalculateRequest) CalculateResponse
}

type CalculateRequest struct{}

type CalculateResponse struct {
	result int
}
```