### PR TITLE
This change updates golang.org/x/tools to v0.24.1.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/gobuffalo/tags v2.1.7+incompatible // indirect
 	github.com/matryer/is v1.4.0
 	github.com/pkg/errors v0.9.1
-	golang.org/x/tools v0.23.0
+	golang.org/x/tools v0.24.1
 )


### PR DESCRIPTION
This fixes the broken `go install github.com/pacedotdev/oto@latest` which due to a broken package in go 1.25 

Fixes: https://github.com/golang/go/issues/74462